### PR TITLE
iOS MediaElementRenderer. Crash when player is pausing after dispose _rateObserver

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if(_rateObserver != null)
 			{
-				_rateObserver.Dispose();
+				_avPlayerViewController?.Player?.RemoveObserver(_rateObserver, "rate");
 				_rateObserver = null;
 			}
 


### PR DESCRIPTION
### Issues Resolved ### 
iOS MediaElementRenderer. Crash when player is pausing after dispose _rateObserver


### Platforms Affected ### 
- iOS
