### PR TITLE
Fix: Android. MediaElementRenderer crash

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/MediaElementRenderer.cs
@@ -472,9 +472,15 @@ namespace Xamarin.Forms.Platform.Android
 			if (_view != null)
 			{
 				_view.MetadataRetrieved -= MetadataRetrieved;
-				RemoveView(_view);
-				_view.SetOnPreparedListener(null);
-				_view.SetOnCompletionListener(null);
+
+                try
+                {
+					RemoveView(_view);
+					_view.SetOnPreparedListener(null);
+					_view.SetOnCompletionListener(null);
+				}
+                catch (Exception ex){}
+
 				_view.Dispose();
 				_view = null;
 			}


### PR DESCRIPTION
### Description of Change ###
MediaElementRenderer Dispose is called late when MediaElement in navigation stack and an application doing work with media (as examle), but a video view already disposed

### Issues Resolved ### 
Crash when trying remove view but _view is disposed

### Platforms Affected ### 
- Android
